### PR TITLE
Backfill tests to increase coverage

### DIFF
--- a/spec/features/users/profile/edit_spec.rb
+++ b/spec/features/users/profile/edit_spec.rb
@@ -1,65 +1,80 @@
 require 'rails_helper'
 
-RSpec.describe 'As a User' do 
-    describe 'When I visit my profile page' do 
-        before :each do 
-            @user = create(:user)
-            @user.confirm
+RSpec.describe 'As a User' do
+  describe 'When I visit my profile page' do
+    before :each do
+      @user = create(:user)
+      @user.confirm
 
-            visit '/'
+      visit '/'
 
-            expect(page).to have_content("Sign In")
+      expect(page).to have_content("Sign In")
 
-            click_on "Sign In"
+      click_on "Sign In"
 
-            expect(current_path).to eq('/users/sign_in')
+      expect(current_path).to eq('/users/sign_in')
 
-            fill_in :user_email, with: @user.email
-            fill_in :user_password, with: @user.password
-            
+      fill_in :user_email, with: @user.email
+      fill_in :user_password, with: @user.password
 
-            click_on "Log in"
 
-            expect(current_path).to eq("/")
+      click_on "Log in"
 
-            click_on "Profile"
+      expect(current_path).to eq("/")
 
-            expect(current_path).to eq(profile_path)
-        end
+      click_on "Profile"
 
-        it 'I can edit my profile' do 
-
-            expect(page).to have_link("Edit")
-
-            click_on "Edit"
-
-            expect(current_path).to eq("/profile/edit")
-
-            fill_in :last_name, with: "McFakerson"
-
-            click_on "Submit"
-
-            expect(current_path).to eq("/profile")
-
-            expect(page).to have_content("McFakerson")
-            expect(page).not_to have_content(@user.last_name)
-        end
-
-        it 'I can edit my password seperately from editing my profile' do 
-
-            expect(page).to have_link("Change your password")
-
-            click_on "Change your password"
-
-            expect(current_path).to eq("/users/edit")
-
-            fill_in :user_password, with: "FakePassword"
-            fill_in :user_password_confirmation, with: "FakePassword"
-            fill_in :user_current_password, with: @user.password 
-
-            click_on "Update"
-
-            expect(current_path).to eq("/")
-        end
+      expect(current_path).to eq(profile_path)
     end
+
+    it 'I can edit my profile' do
+
+        expect(page).to have_link("Edit")
+
+        click_on "Edit"
+
+        expect(current_path).to eq("/profile/edit")
+
+        fill_in :last_name, with: "McFakerson"
+
+        click_on "Submit"
+
+        expect(current_path).to eq("/profile")
+
+        expect(page).to have_content("McFakerson")
+        expect(page).not_to have_content(@user.last_name)
+    end
+
+    it 'I can edit my password seperately from editing my profile' do
+
+      expect(page).to have_link("Change your password")
+
+      click_on "Change your password"
+
+      expect(current_path).to eq("/users/edit")
+
+      fill_in :user_password, with: "FakePassword"
+      fill_in :user_password_confirmation, with: "FakePassword"
+      fill_in :user_current_password, with: @user.password
+
+      click_on "Update"
+
+      expect(current_path).to eq("/")
+    end
+
+    it 'I cannot update profile without all fields filled in' do
+      expect(page).to have_link("Edit")
+
+      click_on "Edit"
+
+      expect(current_path).to eq("/profile/edit")
+
+      fill_in :last_name, with: ""
+
+      click_on "Submit"
+
+      expect(current_path).to eq("/profile/edit")
+      expect(page).to have_content("Last name can't be blank")
+    end
+  end
 end

--- a/spec/features/users/questions/delete_spec.rb
+++ b/spec/features/users/questions/delete_spec.rb
@@ -1,0 +1,67 @@
+require 'rails_helper'
+
+RSpec.describe 'As a user' do
+  describe 'I can delete a professional or technical question' do
+    before :each do
+      Question.destroy_all
+      @user = create(:user)
+      @user.confirm
+
+      visit '/'
+
+      expect(page).to have_content("Sign In")
+
+      click_on "Sign In"
+
+      expect(current_path).to eq('/users/sign_in')
+
+      fill_in :user_email, with: @user.email
+      fill_in :user_password, with: @user.password
+
+      click_on "Log in"
+
+      expect(current_path).to eq("/")
+
+      @question_1 = Question.create!({subject: "Ruby methods",
+                                      content: "What is attr_reader?",
+                                      upvotes: 1,
+                                      forum: 0,
+                                      user_id: @user.id})
+
+      @question_2 = Question.create!({subject: "Jobs",
+                                      content: "Why can't I get a job?",
+                                      upvotes: 1,
+                                      forum: 1,
+                                      user_id: @user.id})
+
+      @question_3 = Question.create!({subject: "Ruby methods",
+                                      content: "What is attr_accessor?",
+                                      upvotes: 1,
+                                      forum: 0,
+                                      user_id: @user.id})
+
+      @question_4 = Question.create!({subject: "Interviews",
+                                      content: "Best interview practices",
+                                      upvotes: 1,
+                                      forum: 1,
+                                      user_id: @user.id})
+    end
+
+    it "I can delete a question from the professional forum" do
+      visit '/profile'
+
+      within "#question-#{@question_2.id}" do
+        click_on @question_2.subject
+      end
+
+      expect(current_path).to eq("/questions/#{@question_2.id}")
+
+      within ".question-modification" do
+        click_on "Delete Question"
+      end
+
+      expect(current_path).to eq("/#{@question_2.forum}_forum")
+      expect(page).to have_content("Your question was successfully deleted.")
+    end
+  end
+end

--- a/spec/features/users/questions/edit_spec.rb
+++ b/spec/features/users/questions/edit_spec.rb
@@ -47,8 +47,9 @@ RSpec.describe 'As a user' do
                                       user_id: @user.id})
     end
 
-    it "I can update a question" do
+    it "I can update a professional question" do
       visit '/profile'
+
       within "#question-#{@question_2.id}" do
         click_on @question_2.subject
       end
@@ -67,6 +68,29 @@ RSpec.describe 'As a user' do
 
       expect(current_path).to eq("/questions/#{@question_2.id}")
       expect(page).to have_content("Career advice")
+    end
+
+    it "I can update a technical question" do
+      visit '/profile'
+
+      within "#question-#{@question_3.id}" do
+        click_on @question_3.subject
+      end
+
+      expect(current_path).to eq("/questions/#{@question_3.id}")
+
+      within ".question-modification" do
+        click_on "Update Question"
+      end
+
+      expect(current_path).to eq("/questions/#{@question_3.id}/edit")
+
+      fill_in :question_subject, with: "Ruby ruby"
+
+      click_on "Update Question"
+
+      expect(current_path).to eq("/questions/#{@question_3.id}")
+      expect(page).to have_content("Ruby ruby")
     end
 
     it "I cannot leave a field blank when updating a question" do
@@ -89,6 +113,28 @@ RSpec.describe 'As a user' do
 
       expect(current_path).to eq("/questions/#{@question_2.id}/edit")
       expect(page).to have_content("Subject can't be blank")
+    end
+
+    it "I cannot leave a field blank when updating a question" do
+      visit '/profile'
+      within "#question-#{@question_2.id}" do
+        click_on @question_2.subject
+      end
+
+      expect(current_path).to eq("/questions/#{@question_2.id}")
+
+      within ".question-modification" do
+        click_on "Update Question"
+      end
+
+      expect(current_path).to eq("/questions/#{@question_2.id}/edit")
+
+      fill_in :question_content, with: ""
+
+      click_on "Update Question"
+
+      expect(current_path).to eq("/questions/#{@question_2.id}/edit")
+      expect(page).to have_content("Content can't be blank")
     end
   end
 end

--- a/spec/features/users/questions/new_spec.rb
+++ b/spec/features/users/questions/new_spec.rb
@@ -64,5 +64,24 @@ RSpec.describe 'As a user' do
       expect(page).to have_content(content)
       expect(page).to have_content("Your question was successfully submitted!")
     end
+
+    it "I cannot create a question without filling out proper information" do
+      visit '/questions/new'
+
+      expect(page).to have_content("Post a Question:")
+
+      subject = 'Jobs'
+      content = 'How do I get one?'
+
+      within '.new_question' do
+        choose 'question_forum_1'
+        fill_in :question_subject, with: ""
+        fill_in :question_content, with: content
+        click_on 'Submit Question'
+      end
+
+      expect(current_path).to eq("/questions/new")
+      expect(page).to have_content("Subject can't be blank")
+    end
   end
 end


### PR DESCRIPTION
# Description :: User Story

- Backfill tests to increase coverage and sad paths. 

## Type of change

- [ ] New Feature
- [ ] Bug Fix
- [x] Refactor
- [ ] Breaking Change

## Notes

## RSpec results

```
Finished in 5.39 seconds (files took 4.11 seconds to load)
60 examples, 0 failures

Coverage report generated for RSpec to /Users/davidholtkamp521/turing/3module/projects/Turing.SO/coverage. 159 / 228 LOC (69.74%) covered.
```

## Rubocop results

```
27 files inspected, 8 offenses detected
```
