### PR TITLE
implemented validation helpers

### DIFF
--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -1,5 +1,6 @@
 class Answer < ApplicationRecord
   validates_presence_of :content
+  validates :content, length: { maximum: 200, too_long: "%{count} characters is the maximum allowed" }
 
   has_many :comments, as: :commentable
 

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,5 +1,6 @@
 class Comment < ApplicationRecord
   validates_presence_of :content
+  validates :content, length: { maximum: 200, too_long: "%{count} characters is the maximum allowed" }
 
   belongs_to :commentable, polymorphic: true
   belongs_to :user

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -1,6 +1,8 @@
 class Question < ApplicationRecord
   validates_presence_of :subject
   validates_presence_of :content
+  validates :content, length: {maximum: 200, too_long: "%{count} characters is the maximum allowed"}
+  validates :subject, length: { maximum: 90, too_long: "%{count} characters is the maximum allowed" }
   validates :forum, presence: true
 
   enum forum: %i[technical professional]

--- a/spec/features/users/answers/comments/new_spec.rb
+++ b/spec/features/users/answers/comments/new_spec.rb
@@ -76,6 +76,22 @@ RSpec.describe 'As a user' do
         expect(page).not_to have_content('I think this is a good start but also I know there is more to it.')
         expect(page).to have_content("Content can't be blank")
       end
+
+      it 'I can not make a comment answer if the content is over 200.' do
+        within "#answer-#{@answer_1.id}" do
+          expect(page).to have_link('Leave a Comment')
+          click_on 'Leave a Comment'
+        end
+
+        expect(current_path).to eq("/questions/#{@question_1.id}/answers/#{@answer_1.id}/comments/new")
+
+        fill_in :content, with: "I am sorry" * 300 
+
+        click_on 'Submit'
+
+        expect(page).not_to have_content('I think this is a good start but also I know there is more to it.')
+        expect(page).to have_content("Content 200 characters is the maximum allowed")
+      end
     end
   end
 end

--- a/spec/features/users/answers/new_spec.rb
+++ b/spec/features/users/answers/new_spec.rb
@@ -67,5 +67,20 @@ RSpec.describe 'As a User' do
       expect(page).not_to have_content('An attr_reader is a method from a super class that allows other files to read the methods in the file the attr_reader is in.')
       expect(page).to have_content("Content can't be blank")
     end
+
+    it 'I cannot make an answer if its content is higher than 200.' do
+      expect(page).to have_link('Answer Question')
+
+      click_on 'Answer Question'
+
+      expect(current_path).to eq("/questions/#{@question_1.id}/answers/new")
+
+      fill_in :content, with: "mommy" * 200
+
+      click_on 'Submit'
+
+      expect(page).not_to have_content('An attr_reader is a method from a super class that allows other files to read the methods in the file the attr_reader is in.')
+      expect(page).to have_content("Content 200 characters is the maximum allowed")
+    end
   end
 end

--- a/spec/features/users/questions/comments/new_spec.rb
+++ b/spec/features/users/questions/comments/new_spec.rb
@@ -67,5 +67,20 @@ RSpec.describe 'As a User' do
       expect(page).to have_content("Content can't be blank")
       expect(page).not_to have_content('Yes I herd my instructor say that in class but I also have no idea what that is.')
     end
+
+    it 'I cannot make a question if I use to many characters' do 
+      expect(page).to have_link('Leave a Comment')
+
+      click_on 'Leave a Comment'
+
+      expect(current_path).to eq("/questions/#{@question_1.id}/comments/new")
+
+      fill_in :content, with: "but why" * 100
+
+      click_on 'Submit'
+
+      expect(page).to have_content("Content 200 characters is the maximum allowed")
+      expect(page).not_to have_content('Yes I herd my instructor say that in class but I also have no idea what that is.')
+    end
   end
 end

--- a/spec/features/users/questions/new_spec.rb
+++ b/spec/features/users/questions/new_spec.rb
@@ -82,5 +82,23 @@ RSpec.describe 'As a user' do
       expect(current_path).to eq('/questions/new')
       expect(page).to have_content("Subject can't be blank")
     end
+
+    it 'I cannot make a question the is to long' do 
+      visit '/questions/new'
+
+      expect(page).to have_content('Post a Question:')
+
+      subject = 'Ruby methods'
+      content = 'What is reduce good for?'
+
+      within '.new_question' do
+        choose 'question_forum_technical'
+        fill_in :question_subject, with: "why" * 91
+        fill_in :question_content, with: content
+        click_on 'Submit Question'
+      end
+
+      expect(page).to have_content("Subject 90 characters is the maximum allowed")
+    end
   end
 end


### PR DESCRIPTION
# Description :: User Story
Form protections for Questions, Answers, and comments: limit length, confirm input type, etc.
## Type of change

- [ ] New Feature
- [ ] Bug Fix
- [X] Refactor
- [ ] Breaking Change

## Notes
This PR has a limiter put on all the questions, comments or answers so that users cannot type in an infinite question. I set the question subject maximum to 90, only because 90 is really a lot fewer characters than you think, and the content is at a max of 300 characters for all. 

## RSpec results

<img width="1440" alt="Screen Shot 2020-04-14 at 8 15 20 PM" src="https://user-images.githubusercontent.com/51456013/79291749-ad864300-7e8c-11ea-8504-850a3ab3ad54.png">


## Rubocop results

<img width="1438" alt="Screen Shot 2020-04-14 at 8 16 09 PM" src="https://user-images.githubusercontent.com/51456013/79291787-cb53a800-7e8c-11ea-8e3f-eace7aa91519.png">

