### PR TITLE
Jww heroku bug 1

### DIFF
--- a/app/views/partials/_forum.html.erb
+++ b/app/views/partials/_forum.html.erb
@@ -11,9 +11,9 @@
       <h4><%= link_to question.subject, "/questions/#{question.id}" %></h4>
       <div class="questionContent">:: <%= question.content.first(50) + "..." %></div>
       <div class="questionBoxInfo">Posted By :: <%= question.user.first_name %></div>
-      <div class='questionBoxSpacer'><%= image_tag 'turing_vertical_spacer' %></div>
+      <div class='questionBoxSpacer'><%= image_tag 'turing_vertical_spacer.png' %></div>
       <div class="questionBoxInfo">Cohort :: <%= question.user.cohort %></div>
-      <div class='questionBoxSpacer'><%= image_tag 'turing_vertical_spacer' %></div>
+      <div class='questionBoxSpacer'><%= image_tag 'turing_vertical_spacer.png' %></div>
       Comments :: <%= question.comments.count %>
     </div>
   </div>

--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -2,11 +2,11 @@
 <div class="row mb-3">
   <div class="col-md-8 themed-grid-col question"><%= @question.subject %> :: <%= @question.upvotes %>
     <% if current_user.nil? %>
-      :: <%= image_tag 'upvote' %>
+      :: <%= image_tag 'upvote.png' %>
     <% elsif current_user.upvoted?(@question) || current_user.id == @question.user_id %>
-      :: <%= image_tag 'upvote' %>
+      :: <%= image_tag 'upvote.png' %>
     <% else %>
-      :: <%= link_to image_tag('upvote', alt: 'Upvote'), question_upvote_path(@question), method: :post %>
+      :: <%= link_to image_tag('upvote.png', alt: 'Upvote'), question_upvote_path(@question), method: :post %>
     <% end %>
     <% if current_user %>
       <div class='answerQuestionLink'>
@@ -88,11 +88,11 @@
     <div class="row mb-3 answerSig">
       <div class="col-md-8 themed-grid-col answer">Answer :: <%= answer.upvotes %>
         <% if current_user.nil? %>
-          :: <%= image_tag 'upvote' %>
+          :: <%= image_tag 'upvote.png' %>
         <% elsif current_user.upvoted?(answer) || current_user.id == answer.user_id %>
-          :: <%= image_tag 'upvote' %>
+          :: <%= image_tag 'upvote.png' %>
         <% else %>
-          :: <%= link_to image_tag('upvote', alt: 'Upvote'), answer_upvote_path(answer), method: :post %>
+          :: <%= link_to image_tag('upvote.png', alt: 'Upvote'), answer_upvote_path(answer), method: :post %>
         <% end %>
       </div>
 
@@ -150,7 +150,7 @@
             <% elsif current_user.upvoted?(answer_comment) || current_user.id == answer_comment.user_id %>
               <%= answer_comment.upvotes %> ::
             <% else %>
-              <%= answer_comment.upvotes %> :: <%= link_to 'upvote', answer_comment_upvote_path(answer_comment), method: :post %> 
+              <%= answer_comment.upvotes %> :: <%= link_to 'upvote.png', answer_comment_upvote_path(answer_comment), method: :post %> 
             <% end %>
             
             <% if current_user && current_user.id == answer_comment.user_id %>

--- a/app/views/users/profile/show.html.erb
+++ b/app/views/users/profile/show.html.erb
@@ -5,7 +5,7 @@
   <h2><%= @user.first_name %> <%= @user.last_name %></h2>
   <h4>Cohort: <%= @user.cohort %></h4>
   <div>
-    <%= image_tag 'turing_logo', width: 50, height: 50 %>
+    <%= image_tag 'turing_logo.png', width: 50, height: 50 %>
     Turing Status: <%= @user.status %>
   </div>
 </section>
@@ -16,7 +16,7 @@
   </div>
 <% else %>
   <div>
-    <%= image_tag 'github-logo-lg', width: 50, height: 50 %>
+    <%= image_tag 'github-logo-lg.png', width: 50, height: 50 %>
     GitHub Account Connected
   </div>
 <% end %>
@@ -27,16 +27,16 @@
   </div>
 <% elsif !@user.award_count.zero? %>
   <div>
-    <%= image_tag 'so-icon-lg', width: 50, height: 50 %>
+    <%= image_tag 'so-icon-lg.png', width: 50, height: 50 %>
     StackOverflow Account Connected
   </div>
   <div id='so_badges'>
-    <%= image_tag 'medal', width: 50, height: 50 %>
+    <%= image_tag 'medal.png', width: 50, height: 50 %>
     StackOverflow Award Count: <%= @user.award_count %>
   </div>
 <% else %>
   <div>
-    <%= image_tag 'so-icon-lg', width: 50, height: 50 %>
+    <%= image_tag 'so-icon-lg.png', width: 50, height: 50 %>
     StackOverflow Account Connected
   </div>
   <p>You have no awards!</p>


### PR DESCRIPTION
# Description :: User Story

This PR fixes a Heroku bug that was causing `500` errors. The Heroku logs showed that errors occurred when a route and view was execueted that included an `image_tag 'filename'` without the file type extension included with the filename. This error should be resolved by the following syntax update:

`image_tag 'filename.png'`

I searched the project globally for all references to images and replaced the references to them with the updated syntax. All tests pass, but I can't be sure this fix will work until it's deployed to Heroku.

## Type of change

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Breaking Change

## Notes

Test coverage is down since the update @alerrian and I pushed earlier, but I think @sasloan added more test coverage for Divise? Perhaps I'm missing something because it's late and I'm brain dead, help friends! 😁 

I did not fix Rubocop errors in this PR.

## RSpec results

```
......................................................................................

Finished in 8.9 seconds (files took 3.33 seconds to load)
86 examples, 0 failures

Coverage report generated for RSpec to /Users/jww/turing/3module/projects/kaizen/coverage. 277 / 330 LOC (83.94%) covered.
```

## Rubocop results

```
28 files inspected, 35 offenses detected
```
