### PR TITLE
Jww profile icons

### DIFF
--- a/app/helpers/devise_helper.rb
+++ b/app/helpers/devise_helper.rb
@@ -9,7 +9,7 @@ module DeviseHelper
         <span aria-hidden="true">&times;</span>
       </button>
       <strong>
-       #{pluralize(resource.errors.count, "error")} must be fixed
+       #{pluralize(resource.errors.count, 'error')} must be fixed
       </strong>
       #{messages}
     </div>

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -1,6 +1,6 @@
 class Answer < ApplicationRecord
   validates_presence_of :content
-  validates :content, length: { maximum: 200, too_long: "%{count} characters is the maximum allowed" }
+  validates :content, length: { maximum: 200, too_long: '%{count} characters is the maximum allowed' }
 
   has_many :comments, as: :commentable
   has_many :votes, as: :voteable

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,6 +1,6 @@
 class Comment < ApplicationRecord
   validates_presence_of :content
-  validates :content, length: { maximum: 200, too_long: "%{count} characters is the maximum allowed" }
+  validates :content, length: { maximum: 200, too_long: '%{count} characters is the maximum allowed' }
 
   belongs_to :commentable, polymorphic: true
   belongs_to :user

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -1,8 +1,8 @@
 class Question < ApplicationRecord
   validates_presence_of :subject
   validates_presence_of :content
-  validates :content, length: {maximum: 200, too_long: "%{count} characters is the maximum allowed"}
-  validates :subject, length: { maximum: 90, too_long: "%{count} characters is the maximum allowed" }
+  validates :content, length: { maximum: 200, too_long: '%{count} characters is the maximum allowed' }
+  validates :subject, length: { maximum: 90, too_long: '%{count} characters is the maximum allowed' }
   validates :forum, presence: true
 
   enum forum: %i[technical professional]

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,7 +31,7 @@ class User < ApplicationRecord
     resp = JSON.parse(kapi.find_awards)
 
     if resp['items'].empty?
-      return 0
+      0
     else
       resp['items'].first['award_count']
     end
@@ -42,6 +42,6 @@ class User < ApplicationRecord
   end
 
   def upvoted?(resource)
-    !resource.votes.find_by(user_id: self.id).nil?
+    !resource.votes.find_by(user_id: id).nil?
   end
 end

--- a/app/views/users/profile/show.html.erb
+++ b/app/views/users/profile/show.html.erb
@@ -12,6 +12,7 @@
 
 <% if @user.gh_token.nil? %>
   <div id='github_auth'>
+    <%= image_tag 'github-logo-lg.png', width: 50, height: 50 %>
     <%= link_to 'Connect to GitHub', user_github_omniauth_authorize_path %>
   </div>
 <% else %>
@@ -23,6 +24,7 @@
 
 <% if @user.so_token.nil? %>
   <div id='stackoverflow_auth'>
+    <%= image_tag 'so-icon-lg.png', width: 50, height: 50 %>
     <%= link_to 'Connect to StackOverflow', user_stackexchange_omniauth_authorize_path %>
   </div>
 <% elsif !@user.award_count.zero? %>


### PR DESCRIPTION
# Description :: User Story

This PR updates the user's profile view to include the `GitHub` and `StackOverflow` icons regardless of if the user has authenticated those accounts.

## Type of change

- [x] New Feature
- [ ] Bug Fix
- [x] Refactor
- [ ] Breaking Change

## Notes

I fixed some Rubocop violations in this PR.

## RSpec results

```
......................................................................................

Finished in 9.06 seconds (files took 2.62 seconds to load)
86 examples, 0 failures

Coverage report generated for RSpec to /Users/jww/turing/3module/projects/kaizen/coverage. 277 / 330 LOC (83.94%) covered.
```

## Rubocop results

```
28 files inspected, 24 offenses detected
```
