### PR TITLE
Update production environment to force ssl connections

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -44,7 +44,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.


### PR DESCRIPTION
# Description :: User Story

Enable force SSL in the production environment. The application domain:

kaizen.fyi

Now supports SSL connections through Heroku.

## Type of change

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Breaking Change

## Notes

## RSpec results

```
Paste RSpec results here
```

## Rubocop results

```
Paste Rubocop results here
```
