### PR TITLE
Fix spelling error: buit is now built

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,5 +109,5 @@
     ``` 
  
  ### Contributions
-  * Buit by :: [Dave](https://github.com/DavidHoltkamp1), [Jordan](https://github.com/iEv0lv3), [Sebastian](https://github.com/sasloan), and [Steve](https://github.com/alerrian)
+  * Built by :: [Dave](https://github.com/DavidHoltkamp1), [Jordan](https://github.com/iEv0lv3), [Sebastian](https://github.com/sasloan), and [Steve](https://github.com/alerrian)
   * Continuous Integration through [TravisCI](https://docs.travis-ci.com/)


### PR DESCRIPTION
# Description :: User Story

Fix `README.md` spelling mistake.

Was `buit` now `built`

## Type of change

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Breaking Change

## Notes

## RSpec results

```
Paste RSpec results here
```

## Rubocop results

```
Paste Rubocop results here
```
