### PR TITLE
Update Heroku Procfile to use the standard rails sever call

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: bundle exec puma
+web: bin/rails server -p ${PORT:-5000} -e $RAILS_ENV
 worker: bundle exec sidekiq -t 25


### PR DESCRIPTION
# Description :: User Story

Update the Procfile call that starts the Puma server in Rails. It is now the standard call.

## Type of change

- [ ] New Feature
- [ ] Bug Fix
- [X] Refactor
- [ ] Breaking Change

## Notes

## RSpec results

```
Paste RSpec results here
```

## Rubocop results

```
Paste Rubocop results here
```
