### PR TITLE
Jww es model client

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,7 @@ gem 'will_paginate'
 gem 'bootsnap', '>= 1.4.2', require: false
 
 # Elasticsearch gems
-gem 'elasticsearch', '~> 7.6.0'
+gem 'elasticsearch', '~> 7.1.0'
 gem 'elasticsearch-model', '~> 7.1.0'
 gem 'elasticsearch-rails', '~> 7.1.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,10 +99,10 @@ GEM
       warden (~> 1.2.3)
     diff-lcs (1.3)
     docile (1.3.2)
-    elasticsearch (7.6.0)
-      elasticsearch-api (= 7.6.0)
-      elasticsearch-transport (= 7.6.0)
-    elasticsearch-api (7.6.0)
+    elasticsearch (7.1.0)
+      elasticsearch-api (= 7.1.0)
+      elasticsearch-transport (= 7.1.0)
+    elasticsearch-api (7.1.0)
       multi_json
     elasticsearch-extensions (0.0.31)
       ansi
@@ -112,8 +112,8 @@ GEM
       elasticsearch (> 1)
       hashie
     elasticsearch-rails (7.1.0)
-    elasticsearch-transport (7.6.0)
-      faraday (~> 1)
+    elasticsearch-transport (7.1.0)
+      faraday
       multi_json
     erubi (1.9.0)
     factory_bot (5.1.2)
@@ -339,7 +339,7 @@ DEPENDENCIES
   byebug
   capybara (>= 2.15)
   devise
-  elasticsearch (~> 7.6.0)
+  elasticsearch (~> 7.1.0)
   elasticsearch-extensions
   elasticsearch-model (~> 7.1.0)
   elasticsearch-rails (~> 7.1.0)

--- a/app/facades/search_facade.rb
+++ b/app/facades/search_facade.rb
@@ -1,13 +1,33 @@
 class SearchFacade
-  attr_reader :results
+  attr_reader :results,
+              :aws_results
 
   def initialize(query)
-    @results = search_connection(query)
+    @aws_es = AwsEsService.new
+    # @results = search_connection(query)
+    @results = aws_search(query)
   end
 
   private
 
-  def search_connection(query)
-    Elasticsearch::Model.search(query, [Question, Answer]).records.to_a
+  # def search_connection(query)
+  #   Elasticsearch::Model.search(query, [Question, Answer]).records.to_a
+  # end
+
+  def aws_search(query)
+    results = @aws_es.search(query)
+    if results[:hits][:total][:value] > 0
+      results[:hits][:hits].reduce([]) do |result_objects, result|
+        model = result[:_index]
+        if model == 'questions'
+          result_objects << Question.find(result[:_source][:id])
+        elsif model == 'answers'
+          result_objects << Answer.find(result[:_source][:id])
+        end
+        result_objects
+      end
+    else
+      []
+    end
   end
 end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -1,3 +1,5 @@
+require 'elasticsearch'
+require 'elasticsearch/api'
 require 'elasticsearch/model'
 require 'sidekiq'
 require 'redis'

--- a/app/services/aws_es_api_service.rb
+++ b/app/services/aws_es_api_service.rb
@@ -2,12 +2,13 @@ require 'elasticsearch'
 require 'elasticsearch/model'
 require 'elasticsearch/api'
 require 'elasticsearch/rails'
+require 'elasticsearch/transport'
 require 'faraday'
 require 'faraday_middleware'
 require 'faraday_middleware/aws_sigv4'
 
 class AwsEsApiService
-  include Elasticsearch::API
+  include Elasticsearch::Model
 
   attr_reader :elasticsearch
 
@@ -18,12 +19,13 @@ class AwsEsApiService
   private
 
   def conn
-    Elasticsearch::Model.client = Elasticsearch::Client.new(host: ENV['AWS_ES'], port: 443) do |faraday|
+    client = Elasticsearch::Client.new(host: ENV['AWS_ES'], port: 443) do |faraday|
       faraday.request :aws_sigv4,
                       service: 'es',
                       region: 'us-west-2',
                       access_key_id: ENV['AWS_ACCESS_KEY'],
                       secret_access_key: ENV['AWS_SECRET_KEY']
     end
+    Elasticsearch::Model.client = client
   end
 end

--- a/app/services/aws_es_service.rb
+++ b/app/services/aws_es_service.rb
@@ -73,7 +73,7 @@ class AwsEsService
   private
 
   def conn
-    Elasticsearch::Model.client = Faraday.new(url: ENV['AWS_ES']) do |faraday|
+    Faraday.new(url: ENV['AWS_ES']) do |faraday|
       faraday.request :aws_sigv4,
                       service: 'es',
                       region: 'us-west-2',

--- a/config/initializers/elasticsearch.rb
+++ b/config/initializers/elasticsearch.rb
@@ -1,15 +1,18 @@
-# if Rails.env == 'production'
-#   require 'elasticsearch'
-#   require 'elasticsearch/api'
-#   require 'faraday'
-#   require 'faraday_middleware'
-#   require 'faraday_middleware/aws_sigv4'
+# require 'elasticsearch'
+# require 'elasticsearch/api'
+# require 'elasticsearch/model'
+# require 'elasticsearch/transport'
+# require 'elasticsearch/rails'
+# require 'faraday'
+# require 'faraday_middleware'
+# require 'faraday_middleware/aws_sigv4'
 
-#   Elasticsearch::Model.client = Elasticsearch::Client.new(host: ENV['AWS_ES'], port: 443) do |faraday|
-#     faraday.request :aws_sigv4,
-#                     service: 'es',
-#                     region: 'us-west-2',
-#                     access_key_id: ENV['AWS_ACCESS_KEY'],
-#                     secret_access_key: ENV['AWS_SECRET_KEY']
-#   end
+# client = Elasticsearch::Client.new(host: ENV['AWS_ES'], port: 80) do |faraday|
+#   faraday.request :aws_sigv4,
+#                   service: 'es',
+#                   region: 'us-west-2',
+#                   access_key_id: ENV['AWS_ACCESS_KEY'],
+#                   secret_access_key: ENV['AWS_SECRET_KEY']
 # end
+
+# Elasticsearch::Model.client = client

--- a/spec/cassettes/AWS_Elasticsearch/cluster_stats.yml
+++ b/spec/cassettes/AWS_Elasticsearch/cluster_stats.yml
@@ -295,4 +295,229 @@ http_interactions:
       string: '{"answers":{"mappings":{"properties":{"content":{"type":"text","analyzer":"english"},"id":{"type":"keyword"}}}}}'
     http_version: null
   recorded_at: Mon, 04 May 2020 03:23:22 GMT
+- request:
+    method: get
+    uri: https://search-kaizen-bnz2vfctyqunfmcvryeiw7pfx4.us-west-2.es.amazonaws.com/_cluster/stats
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.0.1
+      Host:
+      - search-kaizen-bnz2vfctyqunfmcvryeiw7pfx4.us-west-2.es.amazonaws.com
+      X-Amz-Date:
+      - 20200504T043708Z
+      X-Amz-Content-Sha256:
+      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=AKIATFX3YP22KDAJ6MOJ/20200504/us-west-2/es/aws4_request,
+        SignedHeaders=host;user-agent;x-amz-content-sha256;x-amz-date, Signature=fb84fc463c8d4caebe0de9ebc1d8d5dcfe4c44d1bcb14891632522ae44462437
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 04 May 2020 04:37:08 GMT
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '2048'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+    body:
+      encoding: UTF-8
+      string: '{"_nodes":{"total":7,"successful":7,"failed":0},"cluster_name":"218497580724:kaizen","cluster_uuid":"l0iW_jwWQUiqyZh6c1VcRQ","timestamp":1588567028426,"status":"green","indices":{"count":9,"shards":{"total":44,"primaries":21,"replication":1.0952380952380953,"index":{"shards":{"min":2,"max":10,"avg":4.888888888888889},"primaries":{"min":1,"max":5,"avg":2.3333333333333335},"replication":{"min":1.0,"max":3.0,"avg":1.2222222222222223}}},"docs":{"count":13224,"deleted":0},"store":{"size_in_bytes":13984903},"fielddata":{"memory_size_in_bytes":0,"evictions":0},"query_cache":{"memory_size_in_bytes":0,"total_count":0,"hit_count":0,"miss_count":0,"cache_size":0,"cache_count":0,"evictions":0},"completion":{"size_in_bytes":0},"segments":{"count":56,"memory_in_bytes":232000,"terms_memory_in_bytes":161424,"stored_fields_memory_in_bytes":19312,"term_vectors_memory_in_bytes":0,"norms_memory_in_bytes":9856,"points_memory_in_bytes":0,"doc_values_memory_in_bytes":41408,"index_writer_memory_in_bytes":0,"version_map_memory_in_bytes":0,"fixed_bit_set_memory_in_bytes":576,"max_unsafe_auto_id_timestamp":1588035684207,"file_sizes":{}}},"nodes":{"count":{"total":7,"coordinating_only":0,"data":4,"ingest":4,"master":3},"versions":["7.4.2"],"os":{"available_processors":14,"allocated_processors":14,"names":[{"count":7}],"pretty_names":[{"count":7}],"mem":{"total_in_bytes":115607654400,"free_in_bytes":10113269760,"used_in_bytes":105494384640,"free_percent":9,"used_percent":91}},"process":{"cpu":{"percent":0},"open_file_descriptors":{"min":1458,"max":1657,"avg":1536}},"jvm":{"max_uptime_in_millis":123890015,"mem":{"heap_used_in_bytes":2555239488,"heap_max_in_bytes":66449965056},"threads":941},"fs":{"total_in_bytes":64452354048,"free_in_bytes":56869396480,"available_in_bytes":56751955968},"network_types":{"transport_types":{"com.amazon.opendistroforelasticsearch.security.ssl.http.netty.OpenDistroSecuritySSLNettyTransport":7},"http_types":{"filter-jetty":7}},"discovery_types":{"zen":7},"packaging_types":[{"flavor":"oss","type":"tar","count":7}]}}'
+    http_version: null
+  recorded_at: Mon, 04 May 2020 04:37:08 GMT
+- request:
+    method: get
+    uri: https://search-kaizen-bnz2vfctyqunfmcvryeiw7pfx4.us-west-2.es.amazonaws.com/questions,answers//_search?q=ruby
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - 'elasticsearch-ruby/7.6.0 (RUBY_VERSION: 2.7.1; darwin x86_64; Faraday v1.0.1)'
+      Content-Type:
+      - application/json
+      Host:
+      - search-kaizen-bnz2vfctyqunfmcvryeiw7pfx4.us-west-2.es.amazonaws.com
+      X-Amz-Date:
+      - 20200504T044000Z
+      X-Amz-Content-Sha256:
+      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=AKIATFX3YP22KDAJ6MOJ/20200504/us-west-2/es/aws4_request,
+        SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date,
+        Signature=0fc7410c26ff0b1c2cec17327ae693ce335cd26c86a8420e9702d80bbc797763
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Date:
+      - Mon, 04 May 2020 04:40:00 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '192'
+      Connection:
+      - keep-alive
+      X-Amzn-Requestid:
+      - 9b7fe2bd-f3ff-4b7b-98be-749e4c40ae66
+      Access-Control-Allow-Origin:
+      - "*"
+    body:
+      encoding: UTF-8
+      string: '{"message":"The request signature we calculated does not match the
+        signature you provided. Check your AWS Secret Access Key and signing method.
+        Consult the service documentation for details."}'
+    http_version: null
+  recorded_at: Mon, 04 May 2020 04:40:00 GMT
+- request:
+    method: get
+    uri: https://search-kaizen-bnz2vfctyqunfmcvryeiw7pfx4.us-west-2.es.amazonaws.com/_search?q=ruby
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.0.1
+      Host:
+      - search-kaizen-bnz2vfctyqunfmcvryeiw7pfx4.us-west-2.es.amazonaws.com
+      X-Amz-Date:
+      - 20200504T053409Z
+      X-Amz-Content-Sha256:
+      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=AKIATFX3YP22KDAJ6MOJ/20200504/us-west-2/es/aws4_request,
+        SignedHeaders=host;user-agent;x-amz-content-sha256;x-amz-date, Signature=1cddb3876072385ea7a9b26dbc9d242b2c508ccd6ac7a453fb63d00e57721c56
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 04 May 2020 05:34:10 GMT
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '601'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+    body:
+      encoding: UTF-8
+      string: '{"took":81,"timed_out":false,"_shards":{"total":21,"successful":21,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":1.0494217,"hits":[{"_index":"answers","_type":"_doc","_id":"1","_score":1.0494217,"_source":{"id":"1","content":"To
+        get pride to work in ruby you need to put ''require ''minitest/pride'' either
+        at the top of all your tests or in your test_helper."}},{"_index":"questions","_type":"_doc","_id":"1","_score":1.0024122,"_source":{"id":"1","subject":"How
+        do I use pride in Ruby?","content":"I am not sure how to get the pretty rainbow
+        dots in my test run?"}}]}}'
+    http_version: null
+  recorded_at: Mon, 04 May 2020 05:34:10 GMT
+- request:
+    method: get
+    uri: https://search-kaizen-bnz2vfctyqunfmcvryeiw7pfx4.us-west-2.es.amazonaws.com/_search?q=carvana
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.0.1
+      Host:
+      - search-kaizen-bnz2vfctyqunfmcvryeiw7pfx4.us-west-2.es.amazonaws.com
+      X-Amz-Date:
+      - 20200504T060016Z
+      X-Amz-Content-Sha256:
+      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=AKIATFX3YP22KDAJ6MOJ/20200504/us-west-2/es/aws4_request,
+        SignedHeaders=host;user-agent;x-amz-content-sha256;x-amz-date, Signature=bcaeab2d67641c841a81dc3ff4dd93cd0c99c2a12a8b288eaff7b04f1041ec32
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 04 May 2020 06:00:17 GMT
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '163'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+    body:
+      encoding: UTF-8
+      string: '{"took":34,"timed_out":false,"_shards":{"total":21,"successful":21,"skipped":0,"failed":0},"hits":{"total":{"value":0,"relation":"eq"},"max_score":null,"hits":[]}}'
+    http_version: null
+  recorded_at: Mon, 04 May 2020 06:00:17 GMT
+- request:
+    method: get
+    uri: https://search-kaizen-bnz2vfctyqunfmcvryeiw7pfx4.us-west-2.es.amazonaws.com/_search?q=ruby
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.0.1
+      Host:
+      - search-kaizen-bnz2vfctyqunfmcvryeiw7pfx4.us-west-2.es.amazonaws.com
+      X-Amz-Date:
+      - 20200504T060104Z
+      X-Amz-Content-Sha256:
+      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=AKIATFX3YP22KDAJ6MOJ/20200504/us-west-2/es/aws4_request,
+        SignedHeaders=host;user-agent;x-amz-content-sha256;x-amz-date, Signature=d721672801b5fd2f8cf1d997e8dd34e1bfeb6b9ae88ae2108247eaf620a979c8
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 04 May 2020 06:01:05 GMT
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '601'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+    body:
+      encoding: UTF-8
+      string: '{"took":28,"timed_out":false,"_shards":{"total":21,"successful":21,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":1.0494217,"hits":[{"_index":"answers","_type":"_doc","_id":"1","_score":1.0494217,"_source":{"id":"1","content":"To
+        get pride to work in ruby you need to put ''require ''minitest/pride'' either
+        at the top of all your tests or in your test_helper."}},{"_index":"questions","_type":"_doc","_id":"1","_score":1.0024122,"_source":{"id":"1","subject":"How
+        do I use pride in Ruby?","content":"I am not sure how to get the pretty rainbow
+        dots in my test run?"}}]}}'
+    http_version: null
+  recorded_at: Mon, 04 May 2020 06:01:05 GMT
 recorded_with: VCR 5.1.0

--- a/spec/cassettes/As_a_User/When_I_visit_the_home_page_page/I_can_search.yml
+++ b/spec/cassettes/As_a_User/When_I_visit_the_home_page_page/I_can_search.yml
@@ -1,0 +1,50 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://search-kaizen-bnz2vfctyqunfmcvryeiw7pfx4.us-west-2.es.amazonaws.com/_search?q=simplecov
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.0.1
+      Host:
+      - search-kaizen-bnz2vfctyqunfmcvryeiw7pfx4.us-west-2.es.amazonaws.com
+      X-Amz-Date:
+      - 20200504T064925Z
+      X-Amz-Content-Sha256:
+      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=AKIATFX3YP22KDAJ6MOJ/20200504/us-west-2/es/aws4_request,
+        SignedHeaders=host;user-agent;x-amz-content-sha256;x-amz-date, Signature=1d5d6aa8bc5693c82abef05c9767a7f7892a0d9d26eae94eaba1b4095aa6508e
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 04 May 2020 06:49:26 GMT
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '697'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+    body:
+      encoding: UTF-8
+      string: '{"took":22,"timed_out":false,"_shards":{"total":21,"successful":21,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":0.7156682,"hits":[{"_index":"questions","_type":"_doc","_id":"2","_score":0.7156682,"_source":{"id":"2","subject":"How
+        do I make SimpleCov work?","content":"I am so confused, SimpleCov is not working
+        the gem is installed and it is in my test_helper, but it won''t work!! someone
+        please help!"}},{"_index":"answers","_type":"_doc","_id":"2","_score":0.5922034,"_source":{"id":"2","content":"It
+        seems like you forgot to put in SimpleCove.start, that is was makes it kick
+        in. just put it right below your ''require ''simplecove'''' in your test_helper."}}]}}'
+    http_version: null
+  recorded_at: Mon, 04 May 2020 06:49:26 GMT
+recorded_with: VCR 5.1.0

--- a/spec/cassettes/As_a_User/When_I_visit_the_home_page_page/I_can_search_and_return_both_questions_and_answers_with_valid_search_terms.yml
+++ b/spec/cassettes/As_a_User/When_I_visit_the_home_page_page/I_can_search_and_return_both_questions_and_answers_with_valid_search_terms.yml
@@ -1,0 +1,50 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://search-kaizen-bnz2vfctyqunfmcvryeiw7pfx4.us-west-2.es.amazonaws.com/_search?q=simplecov
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.0.1
+      Host:
+      - search-kaizen-bnz2vfctyqunfmcvryeiw7pfx4.us-west-2.es.amazonaws.com
+      X-Amz-Date:
+      - 20200504T064927Z
+      X-Amz-Content-Sha256:
+      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=AKIATFX3YP22KDAJ6MOJ/20200504/us-west-2/es/aws4_request,
+        SignedHeaders=host;user-agent;x-amz-content-sha256;x-amz-date, Signature=5f70c8ad97a3c5d4b21e79013d89bcad98279801d6eee13f17caa65ec6a1b118
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 04 May 2020 06:49:27 GMT
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '697'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+    body:
+      encoding: UTF-8
+      string: '{"took":17,"timed_out":false,"_shards":{"total":21,"successful":21,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":0.7156682,"hits":[{"_index":"questions","_type":"_doc","_id":"2","_score":0.7156682,"_source":{"id":"2","subject":"How
+        do I make SimpleCov work?","content":"I am so confused, SimpleCov is not working
+        the gem is installed and it is in my test_helper, but it won''t work!! someone
+        please help!"}},{"_index":"answers","_type":"_doc","_id":"2","_score":0.5922034,"_source":{"id":"2","content":"It
+        seems like you forgot to put in SimpleCove.start, that is was makes it kick
+        in. just put it right below your ''require ''simplecove'''' in your test_helper."}}]}}'
+    http_version: null
+  recorded_at: Mon, 04 May 2020 06:49:27 GMT
+recorded_with: VCR 5.1.0

--- a/spec/cassettes/As_a_User/When_I_visit_the_home_page_page/I_leave_search_bar_blank_I_stay_on_welcome_page_with_flash_message.yml
+++ b/spec/cassettes/As_a_User/When_I_visit_the_home_page_page/I_leave_search_bar_blank_I_stay_on_welcome_page_with_flash_message.yml
@@ -1,0 +1,45 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://search-kaizen-bnz2vfctyqunfmcvryeiw7pfx4.us-west-2.es.amazonaws.com/_search?q=
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.0.1
+      Host:
+      - search-kaizen-bnz2vfctyqunfmcvryeiw7pfx4.us-west-2.es.amazonaws.com
+      X-Amz-Date:
+      - 20200504T064928Z
+      X-Amz-Content-Sha256:
+      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=AKIATFX3YP22KDAJ6MOJ/20200504/us-west-2/es/aws4_request,
+        SignedHeaders=host;user-agent;x-amz-content-sha256;x-amz-date, Signature=e2a6c339f6443971169f757ddd989b36acf227d4c68b66eae51b326abfc738d0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 04 May 2020 06:49:28 GMT
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '163'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+    body:
+      encoding: UTF-8
+      string: '{"took":10,"timed_out":false,"_shards":{"total":21,"successful":21,"skipped":0,"failed":0},"hits":{"total":{"value":0,"relation":"eq"},"max_score":null,"hits":[]}}'
+    http_version: null
+  recorded_at: Mon, 04 May 2020 06:49:28 GMT
+recorded_with: VCR 5.1.0

--- a/spec/cassettes/As_a_User/When_I_visit_the_home_page_page/if_I_search_something_not_in_the_database_I_am_prompted_to_improve_search.yml
+++ b/spec/cassettes/As_a_User/When_I_visit_the_home_page_page/if_I_search_something_not_in_the_database_I_am_prompted_to_improve_search.yml
@@ -1,0 +1,45 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://search-kaizen-bnz2vfctyqunfmcvryeiw7pfx4.us-west-2.es.amazonaws.com/_search?q=simple%20cov
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.0.1
+      Host:
+      - search-kaizen-bnz2vfctyqunfmcvryeiw7pfx4.us-west-2.es.amazonaws.com
+      X-Amz-Date:
+      - 20200504T064929Z
+      X-Amz-Content-Sha256:
+      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=AKIATFX3YP22KDAJ6MOJ/20200504/us-west-2/es/aws4_request,
+        SignedHeaders=host;user-agent;x-amz-content-sha256;x-amz-date, Signature=2324f7c8f0438e1c3cd60697ab35df5dbf2340879e2776637a52f17af090fbdc
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 04 May 2020 06:49:29 GMT
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '163'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+    body:
+      encoding: UTF-8
+      string: '{"took":27,"timed_out":false,"_shards":{"total":21,"successful":21,"skipped":0,"failed":0},"hits":{"total":{"value":0,"relation":"eq"},"max_score":null,"hits":[]}}'
+    http_version: null
+  recorded_at: Mon, 04 May 2020 06:49:29 GMT
+recorded_with: VCR 5.1.0


### PR DESCRIPTION
# Description :: User Story

Production-ready AWS Elasticsearch functionality.
* Search works as expected with no changes to the search results index view or the search controller
* The search facade was updated to include AWS Elasticsearch
* I used a hammer to create the functionality, and it's all contained in a single `.reduce` method
  * This is not ideal, but it's late and I needed to get this working

I think I figured out the issue with using the `Elasticsearch::Model` gem: the core Elasticsearch gem and sub-gems are all version 7.6, however, I discovered the `Elasticsearch::Model` gem only has compatibility up to version 6. If we downgraded to version 6 it would break the AWS Elasticsearch, which is version 7.4, as well as all current local Elasticsearch clusters. For now I think hand-rolling the search as I did is a decent option, but I want to clean it up.

## Type of change

- [x] New Feature
- [x] Bug Fix
- [x] Refactor
- [ ] Breaking Change

## Notes

## RSpec results

```
Paste RSpec results here
```

## Rubocop results

```
Paste Rubocop results here
```
